### PR TITLE
feat(feed): 시드 스크립트 + 페이지네이션/무한 스크롤 & 캐러셀 드래그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "seed": "node --env-file=.env.local scripts/seed.mjs"
   },
   "dependencies": {
     "@sanity/client": "^6.10.0",

--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -1,0 +1,183 @@
+// Dummy post seeder for local development / pagination testing.
+//
+// Usage (loads .env.local via Node's --env-file):
+//   npm run seed                 # create 30 posts authored by ADMIN_ID
+//   npm run seed -- --count=12   # create 12 posts
+//   npm run seed -- --user=someUsername
+//   npm run seed -- --clean      # delete everything this script created
+//
+// Requires a Sanity *write* (Editor) token in SANITY_SECRET_TOKEN — the same
+// token the app uses for mutations. Seeded docs are tagged `seeded: true` so
+// `--clean` can remove exactly what was added without touching real data.
+
+import { createClient } from '@sanity/client';
+
+const projectId = process.env.SANITY_STUDIO_SANITY_PROJECT_ID;
+const dataset = process.env.SANITY_STUDIO_SANITY_DATASET;
+const token = process.env.SANITY_SECRET_TOKEN;
+
+if (!projectId || !dataset || !token) {
+  console.error(
+    'Missing Sanity env vars. Run with `node --env-file=.env.local` and ensure\n' +
+      'SANITY_STUDIO_SANITY_PROJECT_ID, SANITY_STUDIO_SANITY_DATASET, and SANITY_SECRET_TOKEN are set.'
+  );
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId,
+  dataset,
+  apiVersion: '2023-12-13',
+  token,
+  useCdn: false,
+});
+
+// --- arg parsing ------------------------------------------------------------
+const args = process.argv.slice(2);
+const getArg = (name, fallback) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=')[1] : fallback;
+};
+const clean = args.includes('--clean');
+const count = Number(getArg('count', '30'));
+const authorUsername = getArg('user', process.env.ADMIN_ID);
+
+const SAMPLE_CAPTIONS = [
+  '오늘의 한 컷 📸',
+  'Good vibes only ✨',
+  '주말 나들이',
+  'coffee & code ☕️',
+  '노을이 예쁜 날',
+  'Just another day',
+  '맛집 발견!',
+  'work in progress 🛠️',
+  '산책하기 좋은 날씨',
+  'throwback 🎞️',
+];
+const SAMPLE_COMMENTS = [
+  '멋져요! 👍',
+  'Love this',
+  '와 대박',
+  'nice shot',
+  '여기 어디예요?',
+  '최고 🔥',
+  'so cool',
+  '부럽다 ㅠㅠ',
+];
+
+const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const sample = (arr, n) => [...arr].sort(() => Math.random() - 0.5).slice(0, n);
+
+async function clearSeeded() {
+  console.log('🧹 Removing previously seeded documents...');
+  // Delete seeded posts first, then any seeded users (avoids dangling refs).
+  const posts = await client.delete({ query: '*[_type == "post" && seeded == true]' });
+  const users = await client.delete({ query: '*[_type == "user" && seeded == true]' });
+  console.log(`   removed ${posts.results?.length ?? 0} posts, ${users.results?.length ?? 0} users.`);
+}
+
+async function getAuthor() {
+  if (!authorUsername) {
+    throw new Error('No author username. Set ADMIN_ID in .env.local or pass --user=<username>.');
+  }
+  const author = await client.fetch(`*[_type == "user" && username == $u][0]{_id, username}`, {
+    u: authorUsername,
+  });
+  if (!author?._id) {
+    throw new Error(
+      `User "${authorUsername}" not found. Log in once to create the user doc, or pass an existing --user=<username>.`
+    );
+  }
+  return author;
+}
+
+// Pool of users used as like/comment authors (falls back to the post author).
+async function getUserPool(authorId) {
+  const users = await client.fetch(`*[_type == "user"]{_id}`);
+  const ids = users.map((u) => u._id);
+  return ids.length > 0 ? ids : [authorId];
+}
+
+async function uploadImage(seed) {
+  const url = `https://picsum.photos/seed/${seed}/800/800`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Image fetch failed (${res.status}) for ${url}`);
+  const buffer = Buffer.from(await res.arrayBuffer());
+  const asset = await client.assets.upload('image', buffer, {
+    filename: `seed-${seed}.jpg`,
+    contentType: 'image/jpeg',
+  });
+  return asset._id;
+}
+
+async function createSeedPost(index, author, userPool) {
+  const photoCount = Math.random() < 0.3 ? 2 : 1; // mostly single-image posts
+  const photos = [];
+  for (let p = 0; p < photoCount; p++) {
+    const assetId = await uploadImage(`junsgram-${Date.now()}-${index}-${p}`);
+    photos.push({
+      _key: `photo_${index}_${p}_${Date.now()}`,
+      _type: 'image',
+      asset: { _type: 'reference', _ref: assetId },
+    });
+  }
+
+  // First comment is the post caption (matches how the app creates posts).
+  const comments = [
+    {
+      _key: `caption_${index}_${Date.now()}`,
+      comment: pick(SAMPLE_CAPTIONS),
+      author: { _type: 'reference', _ref: author._id },
+    },
+  ];
+  const extraComments = Math.floor(Math.random() * 3);
+  for (let c = 0; c < extraComments; c++) {
+    comments.push({
+      _key: `comment_${index}_${c}_${Date.now()}`,
+      comment: pick(SAMPLE_COMMENTS),
+      author: { _type: 'reference', _ref: pick(userPool) },
+    });
+  }
+
+  const likers = sample(userPool, Math.floor(Math.random() * Math.min(userPool.length, 5)));
+  const likes = likers.map((id, i) => ({
+    _key: `like_${index}_${i}_${Date.now()}`,
+    _type: 'reference',
+    _ref: id,
+  }));
+
+  return client.create({
+    _type: 'post',
+    seeded: true,
+    author: { _type: 'reference', _ref: author._id },
+    photos,
+    comments,
+    likes,
+  });
+}
+
+async function main() {
+  if (clean) {
+    await clearSeeded();
+    return;
+  }
+
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(`Invalid --count: ${getArg('count', '30')}`);
+  }
+
+  const author = await getAuthor();
+  const userPool = await getUserPool(author._id);
+  console.log(`🌱 Seeding ${count} posts authored by "${author.username}"...`);
+
+  for (let i = 0; i < count; i++) {
+    await createSeedPost(i, author, userPool);
+    process.stdout.write(`\r   created ${i + 1}/${count}`);
+  }
+  console.log(`\n✅ Done. Run \`npm run seed -- --clean\` to remove them.`);
+}
+
+main().catch((err) => {
+  console.error('\n❌ Seed failed:', err.message);
+  process.exit(1);
+});

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -4,6 +4,7 @@ import { isAdmin, withSessionUser } from '@/util/session';
 import { removeBookmark } from '@/service/user';
 import { badRequest, forbidden, notFound, serverError } from '@/lib/http';
 import { deletePostSchema } from '@/lib/validation';
+import { parsePageParam } from '@/lib/pagination';
 
 type SampleItem = {
   filterInfo: Array<{ postIdValue: string; userIdValue: string }>;
@@ -12,9 +13,10 @@ type SampleItem = {
 const MAX_PHOTOS = 10;
 const MAX_PHOTO_BYTES = 10 * 1024 * 1024; // 10MB per image
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const page = parsePageParam(req.nextUrl.searchParams);
   return withSessionUser(async (user) =>
-    getFollowingPostsOf(user.username) //
+    getFollowingPostsOf(user.username, page) //
       .then((data) => NextResponse.json(data))
       .catch(serverError)
   );

--- a/src/app/api/users/[...slug]/route.ts
+++ b/src/app/api/users/[...slug]/route.ts
@@ -1,16 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getLikedOf, getPostsOf, getSavedPostsOf } from '@/service/posts';
+import { parsePageParam } from '@/lib/pagination';
 type Context = {
   params: Promise<{
     slug: string[]; // [ 'qustpwns93', 'posts' ]
   }>;
 };
-export async function GET(_: NextRequest, context: Context) {
+export async function GET(request_: NextRequest, context: Context) {
   const { slug } = await context.params;
   if (!slug || !Array.isArray(slug) || slug.length < 2) {
     return new NextResponse('Bad Request', { status: 400 });
   }
   const [username, query] = slug;
+  const page = parsePageParam(request_.nextUrl.searchParams);
 
   let request = getPostsOf;
   if (query === 'saved') {
@@ -19,5 +21,5 @@ export async function GET(_: NextRequest, context: Context) {
     request = getLikedOf;
   }
 
-  return request(username).then((data) => NextResponse.json(data));
+  return request(username, page).then((data) => NextResponse.json(data));
 }

--- a/src/components/PostGrid.tsx
+++ b/src/components/PostGrid.tsx
@@ -1,10 +1,13 @@
 import GridSpinner from './ui/GridSpinner';
 import PostGridCard from './PostGridCard';
 import usePosts from '@/hooks/posts';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 // user 상세 페이지에서 쓰이는 컴포넌트
 export default function PostGrid() {
-  const { posts, isLoading } = usePosts();
+  const { posts, isLoading, isLoadingMore, isReachingEnd, loadMore } = usePosts();
+  const sentinelRef = useInfiniteScroll(loadMore, !isReachingEnd);
+
   return (
     <div className="w-full text-center">
       {isLoading && <GridSpinner />}
@@ -17,6 +20,9 @@ export default function PostGrid() {
           ))}
       </ul>
       {posts?.length === 0 && <h3 className="text-white text-center pb-8 md:mt-24">해당 게시물이 없습니다.</h3>}
+      {/* 무한 스크롤 센티넬 */}
+      {!isReachingEnd && <div ref={sentinelRef} aria-hidden className="h-1" />}
+      {isLoadingMore && !isLoading && <GridSpinner />}
     </div>
   );
 }

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -3,9 +3,12 @@
 import { PropagateLoader } from 'react-spinners';
 import PostListCard from './PostListCard';
 import usePosts from '@/hooks/posts';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 export default function PostList() {
-  const { posts, isLoading: loading } = usePosts();
+  const { posts, isLoading: loading, isLoadingMore, isReachingEnd, loadMore } = usePosts();
+  const sentinelRef = useInfiniteScroll(loadMore, !isReachingEnd);
+
   return (
     <section>
       {loading && (
@@ -21,6 +24,13 @@ export default function PostList() {
             </li>
           ))}
         </ul>
+      )}
+      {/* 무한 스크롤 센티넬: 화면에 들어오면 다음 페이지를 불러온다. */}
+      {!isReachingEnd && <div ref={sentinelRef} aria-hidden className="h-1" />}
+      {isLoadingMore && !loading && (
+        <div className="text-center my-6">
+          <PropagateLoader size={8} color="red" />
+        </div>
       )}
     </section>
   );

--- a/src/components/PostListCard.tsx
+++ b/src/components/PostListCard.tsx
@@ -3,7 +3,7 @@
 import { Comment, SimplePost } from '@/model/post';
 import Image from 'next/image';
 import ActionBar from './ActionBar';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import PostModal from './PostModal';
 import PostDetail from './PostDetail';
 import PostUserAvatar from './PostUserAvatar';
@@ -24,6 +24,22 @@ export default function PostListCard({ post, priority = false }: Props) {
     postComment(post, comment);
   };
 
+  // 드래그(슬라이드)와 클릭(모달 열기) 구분: 포인터를 내린 위치 대비 이동 거리가
+  // 임계값을 넘으면 드래그로 보고 클릭(모달 오픈)을 무시한다.
+  const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
+  const DRAG_THRESHOLD = 10; // px
+  const handlePointerDown = (e: React.PointerEvent) => {
+    pointerDownPos.current = { x: e.clientX, y: e.clientY };
+  };
+  const handleImageClick = (e: React.MouseEvent) => {
+    const start = pointerDownPos.current;
+    if (start) {
+      const moved = Math.abs(e.clientX - start.x) > DRAG_THRESHOLD || Math.abs(e.clientY - start.y) > DRAG_THRESHOLD;
+      if (moved) return; // 드래그였으므로 모달을 열지 않음
+    }
+    setOpenModal(true);
+  };
+
   return (
     <article className=" pb-2 border-b border-gray-200/50">
       <PostUserAvatar image={userImage} username={username} />
@@ -38,7 +54,8 @@ export default function PostListCard({ post, priority = false }: Props) {
               width={500}
               height={500}
               priority={priority}
-              onClick={() => setOpenModal(true)}
+              onPointerDown={handlePointerDown}
+              onClick={handleImageClick}
             />
           ))}
       </ImageSlide>

--- a/src/components/ui/ImageSlide.tsx
+++ b/src/components/ui/ImageSlide.tsx
@@ -11,10 +11,13 @@ const responsive = {
 
 export default function ImageSlide({ children }: { children: ReactNode }) {
   return (
-    <>
+    // 네이티브 이미지 드래그(HTML5 dragstart)가 캐러셀의 포인터 드래그를 가로채
+    // "넘어가다 마는" 현상을 막는다. preventDefault는 react-multi-carousel의
+    // 마우스(mousedown/move) 기반 드래그에는 영향이 없다.
+    <div onDragStart={(e) => e.preventDefault()} className="select-none">
       <Carousel containerClass="w-full relative z-0 h-[100%]" responsive={responsive}>
         {children}
       </Carousel>
-    </>
+    </div>
   );
 }

--- a/src/hooks/posts.ts
+++ b/src/hooks/posts.ts
@@ -2,27 +2,28 @@ import { useCacheKeys } from '@/context/CacheKeysContext';
 import { Comment, SimplePost } from '@/model/post';
 import { fetcher } from '@/lib/fetcher';
 import { API } from '@/lib/routes';
+import { POSTS_PAGE_SIZE } from '@/lib/pagination';
 import { useCallback } from 'react';
-import useSWR from 'swr';
+import useSWRInfinite from 'swr/infinite';
 
 // Resolved values are discarded (mutate uses populateCache: false); typed as
-// SimplePost[] only to satisfy SWR's mutate signature.
+// the paged shape only to satisfy SWR's mutate signature.
 async function updateLike(id: string, like: boolean) {
-  return fetcher<SimplePost[]>(API.likes, {
+  return fetcher<SimplePost[][]>(API.likes, {
     method: 'PUT',
     body: JSON.stringify({ id, like }),
   });
 }
 
 async function addComment(id: string, comment: string) {
-  return fetcher<SimplePost[]>(API.comments, {
+  return fetcher<SimplePost[][]>(API.comments, {
     method: 'POST',
     body: JSON.stringify({ id, comment }),
   });
 }
 
 async function deleteTargetPost(postId: string) {
-  return fetcher<SimplePost[]>(API.posts, {
+  return fetcher<SimplePost[][]>(API.posts, {
     method: 'DELETE',
     body: JSON.stringify({ postId }),
   });
@@ -30,67 +31,110 @@ async function deleteTargetPost(postId: string) {
 
 export default function usePosts() {
   const cacheKeys = useCacheKeys();
+
+  // 무한 스크롤: 페이지 인덱스별로 `?page=N`을 붙여 ranged 쿼리를 요청한다.
+  // 이전 페이지가 비어 있으면 더 가져올 게 없으므로 키를 끊는다(null).
+  const getKey = useCallback(
+    (index: number, previousPageData: SimplePost[] | null) => {
+      if (previousPageData && previousPageData.length === 0) return null;
+      const base = cacheKeys.postsKey;
+      const sep = base.includes('?') ? '&' : '?';
+      return `${base}${sep}page=${index}`;
+    },
+    [cacheKeys.postsKey]
+  );
+
   const {
-    data: posts, //
+    data: pages, //
+    size,
+    setSize,
     isLoading,
     error,
     mutate,
-  } = useSWR<SimplePost[]>(cacheKeys.postsKey);
+  } = useSWRInfinite<SimplePost[]>(getKey, {
+    // 옵티미스틱 갱신이 잦으므로 mutate 때마다 1페이지를 재검증하지 않는다.
+    revalidateFirstPage: false,
+  });
+
+  // 페이지 배열을 평탄화해 기존 소비처(렌더)가 그대로 단일 배열을 쓰게 한다.
+  const posts = pages ? pages.flat() : undefined;
+  const lastPage = pages?.[pages.length - 1];
+  // 마지막 페이지가 한 페이지 분량보다 적으면 끝에 도달한 것.
+  const isReachingEnd = !!pages && (lastPage?.length ?? 0) < POSTS_PAGE_SIZE;
+  // 아직 로드되지 않은 다음 페이지를 기다리는 중인지.
+  const isLoadingMore = isLoading || (size > 0 && !!pages && typeof pages[size - 1] === 'undefined');
+
+  const loadMore = useCallback(() => {
+    if (isLoadingMore || isReachingEnd) return;
+    setSize((prev) => prev + 1);
+  }, [isLoadingMore, isReachingEnd, setSize]);
+
+  // 평탄화된 단일 post 변경을 모든 페이지에 매핑해 옵티미스틱 데이터를 만든다.
+  const mapPages = useCallback(
+    (transform: (post: SimplePost) => SimplePost | null) =>
+      pages?.map((page) => page.map(transform).filter((p): p is SimplePost => p !== null)),
+    [pages]
+  );
 
   const setLike = useCallback(
     (post: SimplePost, username: string, like: boolean) => {
-      // likes: // like눌렀다면 [기존배열 + 내이름] , 취소 눌렀다면 [배열에서 내이름 뺀거 리턴]
-      const newPost = {
-        ...post,
-        likes: like ? [...post.likes, username] : post.likes.filter((item) => item !== username),
-      };
-      // 서버에서 받아온 posts정보들 => 서버포스트.id === 파람스포스트.id 같다면 ui변경된 포스트로!! 아니라면 기존 포스트
-      const newPosts = posts?.map((p) => (p.id === post.id ? newPost : p));
+      // likes: like면 [기존배열 + 내이름], 취소면 [배열에서 내이름 뺀거]
+      const newPages = mapPages((p) =>
+        p.id === post.id
+          ? { ...p, likes: like ? [...p.likes, username] : p.likes.filter((item) => item !== username) }
+          : p
+      );
 
       return mutate(updateLike(post.id, like), {
-        // api fetch 반응이 오기 전 보여줄 ui data ( 왜냐하면 반응이 오고나서 ui 업데이트를 해준다면 ui변경이 느림 )
-        optimisticData: newPosts,
-        populateCache: false, // api response로 반환된 값을 캐시에 덮어씌우지 않음 (왜냐하면 이미 클라쪽 값이 있기때문 )
-        revalidate: false, // 이미 ui가 원하는 상태로 변경되었으니 백그라운드에서 다시 가져올 필요가 없음
-        rollbackOnError: true, // update시 네트워크 문제 생기면 데이터 롤백 옵션
+        // api fetch 반응이 오기 전 보여줄 ui data ( 반응 후 업데이트는 느리므로 )
+        optimisticData: newPages,
+        populateCache: false, // api response를 캐시에 덮어쓰지 않음 (이미 클라 값이 있음)
+        revalidate: false, // 이미 원하는 상태이니 백그라운드 재요청 불필요
+        rollbackOnError: true, // 네트워크 오류 시 롤백
       });
     },
-    [posts, mutate]
+    [mapPages, mutate]
   );
 
   const postComment = useCallback(
-    (post: SimplePost, comment: Comment) => {
-      const newPost = {
-        ...post,
-        comments: post.comments + 1,
-      };
-      // 서버에서 받아온 posts정보들 => 내가찾는 post라면 ui변경된 포스트로!! 아니라면 기존 포스트 그대로가져가는 배열 반환
-      const newPosts = posts?.map((p) => (p.id === post.id ? newPost : p));
+    (post: SimplePost, _comment: Comment) => {
+      const newPages = mapPages((p) => (p.id === post.id ? { ...p, comments: p.comments + 1 } : p));
 
-      return mutate(addComment(post.id, comment.comment), {
-        // api fetch 반응이 오기 전 보여줄 ui data ( 왜냐하면 반응이 오고나서 ui 업데이트를 해준다면 ui변경이 느림 )
-        optimisticData: newPosts,
-        populateCache: false, // api response로 반환된 값을 캐시에 덮어씌우지 않음 (왜냐하면 이미 클라쪽 값이 있기때문 )
-        revalidate: false, // 이미 ui가 원하는 상태로 변경되었으니 백그라운드에서 다시 가져올 필요가 없음
-        rollbackOnError: true, // update시 네트워크 문제 생기면 데이터 롤백 옵션
-      });
-    },
-    [posts, mutate]
-  );
-
-  const deletePost = useCallback(
-    (postId: string) => {
-      if (!postId) return;
-      const newPost = posts?.filter((post) => post.id !== postId);
-      return mutate(deleteTargetPost(postId), {
-        optimisticData: newPost,
+      return mutate(addComment(post.id, _comment.comment), {
+        optimisticData: newPages,
         populateCache: false,
         revalidate: false,
         rollbackOnError: true,
       });
     },
-    [posts, mutate]
+    [mapPages, mutate]
   );
 
-  return { posts, isLoading, error, setLike, postComment, deletePost };
+  const deletePost = useCallback(
+    (postId: string) => {
+      if (!postId) return;
+      // 해당 post를 모든 페이지에서 제거(null 반환 → filter)
+      const newPages = mapPages((p) => (p.id === postId ? null : p));
+
+      return mutate(deleteTargetPost(postId), {
+        optimisticData: newPages,
+        populateCache: false,
+        revalidate: false,
+        rollbackOnError: true,
+      });
+    },
+    [mapPages, mutate]
+  );
+
+  return {
+    posts,
+    isLoading,
+    isLoadingMore,
+    isReachingEnd,
+    loadMore,
+    error,
+    setLike,
+    postComment,
+    deletePost,
+  };
 }

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+
+// Observe a sentinel element and invoke `onIntersect` when it scrolls into view.
+// `enabled` lets callers stop observing once the last page has been reached.
+export function useInfiniteScroll<T extends HTMLElement = HTMLDivElement>(
+  onIntersect: () => void,
+  enabled = true
+) {
+  const ref = useRef<T>(null);
+  // Keep the latest callback without re-subscribing the observer each render.
+  const callbackRef = useRef(onIntersect);
+  useEffect(() => {
+    callbackRef.current = onIntersect;
+  });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !enabled) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) callbackRef.current();
+      },
+      { rootMargin: '200px' } // prefetch slightly before the sentinel is visible
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [enabled]);
+
+  return ref;
+}

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePage, parsePageParam, pageRange, POSTS_PAGE_SIZE } from './pagination';
+
+describe('normalizePage', () => {
+  it('returns the integer for valid non-negative input', () => {
+    expect(normalizePage(0)).toBe(0);
+    expect(normalizePage(3)).toBe(3);
+    expect(normalizePage('2')).toBe(2);
+  });
+
+  it('floors fractional values', () => {
+    expect(normalizePage(2.9)).toBe(2);
+  });
+
+  it('falls back to 0 for invalid or negative input', () => {
+    expect(normalizePage(-1)).toBe(0);
+    expect(normalizePage('abc')).toBe(0);
+    expect(normalizePage(null)).toBe(0);
+    expect(normalizePage(undefined)).toBe(0);
+    expect(normalizePage(NaN)).toBe(0);
+  });
+});
+
+describe('parsePageParam', () => {
+  it('reads the page param, defaulting to 0 when absent', () => {
+    expect(parsePageParam(new URLSearchParams(''))).toBe(0);
+    expect(parsePageParam(new URLSearchParams('page=4'))).toBe(4);
+    expect(parsePageParam(new URLSearchParams('page=-2'))).toBe(0);
+  });
+});
+
+describe('pageRange', () => {
+  it('computes [start...end) bounds from the page size', () => {
+    expect(pageRange(0)).toEqual({ start: 0, end: POSTS_PAGE_SIZE });
+    expect(pageRange(1)).toEqual({ start: POSTS_PAGE_SIZE, end: POSTS_PAGE_SIZE * 2 });
+    expect(pageRange(2)).toEqual({ start: POSTS_PAGE_SIZE * 2, end: POSTS_PAGE_SIZE * 3 });
+  });
+
+  it('clamps invalid pages to the first page', () => {
+    expect(pageRange(-5)).toEqual({ start: 0, end: POSTS_PAGE_SIZE });
+  });
+});

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,25 @@
+// Shared pagination constants/helpers used by both server (service/API) and
+// client (useSWRInfinite). Keeping the page size in one place ensures the
+// client can detect "last page" by comparing a page's length to POSTS_PAGE_SIZE.
+
+// Small page size so infinite scroll is observable even with modest seed data.
+export const POSTS_PAGE_SIZE = 5;
+
+// Coerce an untrusted `page` value into a safe, non-negative integer.
+export function normalizePage(value: unknown): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+// Parse the `page` query param from a request URL's search params (default 0).
+export function parsePageParam(searchParams: URLSearchParams): number {
+  return normalizePage(searchParams.get('page'));
+}
+
+// GROQ slice bounds for a given page: `[start...end]` (end exclusive).
+export function pageRange(page: number): { start: number; end: number } {
+  const safe = normalizePage(page);
+  const start = safe * POSTS_PAGE_SIZE;
+  return { start, end: start + POSTS_PAGE_SIZE };
+}

--- a/src/service/posts.ts
+++ b/src/service/posts.ts
@@ -1,4 +1,5 @@
 import { GetFullPost, SimplePost } from '@/model/post';
+import { pageRange } from '@/lib/pagination';
 import { client, urlFor } from './sanity';
 const simplePostProjection = `
   ...,
@@ -13,13 +14,16 @@ const simplePostProjection = `
 `; // post.author.username -> post.username
 // [ { asset: {_ref: 'image-400e9a09266fbca8b94ee9ca82900f41a88b2d45-18x34-png'}, _key: 'photo_0_1703674479864' }, { asset: {_ref: 'image-400e9a09266fbca8b94ee9ca82900f41a88b2d45-18x34-png'}, _key: 'photo_0_1703674479864' } ]
 
-export async function getFollowingPostsOf(username: string): Promise<SimplePost[]> {
+// `page` selects a slice of the feed (ranged GROQ) for infinite scroll. The
+// bounds are derived from a validated integer, so inlining them is injection-safe.
+export async function getFollowingPostsOf(username: string, page = 0): Promise<SimplePost[]> {
+  const { start, end } = pageRange(page);
   return client
     .fetch(
       `
       *[_type == "post" && (author->username == $username
       || author._ref in *[_type == "user" && username == $username].following[]._ref)]
-      | order(_createdAt desc){${simplePostProjection}}
+      | order(_createdAt desc)[${start}...${end}]{${simplePostProjection}}
     `,
       { username }
     )
@@ -51,11 +55,12 @@ export async function getPost(id: string): Promise<GetFullPost> {
     .then((post) => ({ ...post, image: mapPost(post) }));
 }
 // ({ ...post, image: urlFor(post.image) })
-export async function getPostsOf(username: string): Promise<SimplePost[]> {
+export async function getPostsOf(username: string, page = 0): Promise<SimplePost[]> {
+  const { start, end } = pageRange(page);
   return client
     .fetch(
       `*[_type == "post" && author->username == $username]
-      | order(_createdAt desc){
+      | order(_createdAt desc)[${start}...${end}]{
         ${simplePostProjection}
       }
     `,
@@ -63,11 +68,12 @@ export async function getPostsOf(username: string): Promise<SimplePost[]> {
     )
     .then(mapPosts);
 }
-export async function getLikedOf(username: string): Promise<SimplePost[]> {
+export async function getLikedOf(username: string, page = 0): Promise<SimplePost[]> {
+  const { start, end } = pageRange(page);
   return client
     .fetch(
       `*[_type == "post" && $username in likes[]->username]
-      | order(_createdAt desc){
+      | order(_createdAt desc)[${start}...${end}]{
         ${simplePostProjection}
       }
     `,
@@ -75,11 +81,12 @@ export async function getLikedOf(username: string): Promise<SimplePost[]> {
     )
     .then(mapPosts);
 }
-export async function getSavedPostsOf(username: string): Promise<SimplePost[]> {
+export async function getSavedPostsOf(username: string, page = 0): Promise<SimplePost[]> {
+  const { start, end } = pageRange(page);
   return client
     .fetch(
       `*[_type == "post" && _id in *[_type == "user" && username == $username].bookmarks[]._ref]
-      | order(_createdAt desc){
+      | order(_createdAt desc)[${start}...${end}]{
         ${simplePostProjection}
       }
     `,


### PR DESCRIPTION
## 개요
HANDOFF #2 단계 — 더미 시드 + 피드 페이지네이션/무한 스크롤을 구현하고, 이미지 캐러셀의 드래그 결함 2건을 수정합니다.

## 변경 사항

### 1. 시드 스크립트
- `scripts/seed.mjs` + `npm run seed`
- picsum.photos 이미지를 Sanity 에셋으로 업로드 후 게시물 생성 (렌더는 `cdn.sanity.io` → next.config 변경 불필요)
- 생성 문서에 `seeded:true` 마커 → `--clean`이 시드 데이터만 정확히 삭제
- 옵션: `--count=N`(기본 30) / `--user=<username>`(기본 `ADMIN_ID`) / `--clean`

### 2. 페이지네이션 (GROQ ranged)
- `lib/pagination.ts`: `POSTS_PAGE_SIZE=5` + page 파싱/슬라이스 헬퍼 (+단위 테스트)
- 4개 피드 GROQ에 `[start...end]` 슬라이스
- `/api/posts`, `/api/users/[...slug]`가 `?page=N` 수신

### 3. 무한 스크롤
- `usePosts` → `useSWRInfinite` (페이지 평탄화로 기존 렌더 소비처 유지, 옵티미스틱 like/comment/delete는 페이지 단위 매핑)
- `useInfiniteScroll` 훅(IntersectionObserver, rootMargin 200px) → PostList·PostGrid 센티넬

### 4. 캐러셀 드래그 수정
- **ImageSlide**: `dragstart` `preventDefault`로 네이티브 이미지 드래그가 캐러셀 포인터 드래그를 가로채던 "넘어가다 마는" 현상 해결 (크로스브라우저)
- **PostListCard**: 포인터 이동 거리(10px 임계값)로 드래그/클릭 구분 → 드래그 시 모달이 열리지 않음

## 검증
- ✅ lint · typecheck · test(20, +6) · build 모두 green
- ✅ 데이터층 페이지네이션 확인: 총 11개, page0=5 / page1=5 / 겹침 0
- ⏳ 브라우저 검증(라이브 로그인 필요): 무한 스크롤 동작, 2장 게시물 드래그/클릭 동작

> 참고: 캐싱(CDN + 태그 재검증)은 토큰 인증 read의 CDN 동작 리스크로 이번 PR에서 의도적으로 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)