### PR TITLE
docs(env): trustHost + AUTH_REDIRECT_PROXY_URL for preview OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,23 @@
 GOOGLE_OAUTH_ID=your-google-oauth-client-id
 GOOGLE_OAUTH_SECRET=your-google-oauth-client-secret
 
-# --- NextAuth (v4) ---
-# NEXTAUTH_URL: the app's base URL (e.g. http://localhost:3000 in dev)
-# NEXTAUTH_SECRET: random string, e.g. `openssl rand -base64 32`
-# NOTE: Auth.js v5 (Phase 3) renames this to AUTH_SECRET.
+# --- Auth.js v5 ---
+# AUTH_SECRET: random string, e.g. `openssl rand -base64 32`.
+AUTH_SECRET=your-random-secret
+#
+# Host detection: `authConfig.trustHost: true` (src/auth.config.ts) lets Auth.js
+# derive the URL from the request host, so DO NOT set AUTH_URL / NEXTAUTH_URL on
+# Vercel — hardcoding it makes preview deployments redirect to that host.
+# For local dev only, you may set the base URL explicitly:
 NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=your-random-secret
+#
+# Preview deployments + OAuth: Google requires pre-registered redirect URIs, but
+# Vercel preview URLs change per branch. AUTH_REDIRECT_PROXY_URL routes the OAuth
+# callback through a single registered (production) URL, then back to the preview.
+# Set this on Vercel **Preview and Production** envs; only the production callback
+# (https://<prod-domain>/api/auth/callback/google) needs to be registered in Google.
+# Leave unset for local dev.
+# AUTH_REDIRECT_PROXY_URL=https://<your-prod-domain>/api/auth
 
 # --- Sanity (sanity.io project settings) ---
 SANITY_STUDIO_SANITY_PROJECT_ID=your-sanity-project-id


### PR DESCRIPTION
## 개요
PR 프리뷰가 프로덕션으로 리다이렉트되던 문제를 잡은 **Vercel 환경 설정(option B)**을 레포에 문서화합니다.

## 적용된 Vercel 변경 (이미 반영됨)
- `NEXTAUTH_URL` 제거 → `authConfig.trustHost: true`로 호스트 자동감지 (프리뷰가 자기 호스트 사용)
- `AUTH_REDIRECT_PROXY_URL=https://junsgram.vercel.app/api/auth`를 **Preview + Production**에 추가
  → 프리뷰 OAuth 콜백을 등록된 프로덕션 콜백으로 프록시 후 프리뷰로 복귀 (Google에 프리뷰별 URI 등록 불필요)
- 프로덕션 재배포로 활성화 완료, 인증 엔드포인트 health-check 정상

## 이 PR의 변경
- `.env.example`: Auth.js v5 기준으로 `AUTH_SECRET` / `trustHost` / `AUTH_REDIRECT_PROXY_URL` 설명 갱신

## 검증 포인트
- 이 PR의 **프리뷰 URL이 프로덕션으로 더 이상 리다이렉트되지 않아야 함** (option B 실검증)
- 프리뷰에서 Google 로그인 시 프로덕션 콜백 경유 후 프리뷰로 복귀하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)