### PR TITLE
fix(carousel): restore image height chain in detail modal

### DIFF
--- a/src/components/ui/ImageSlide.tsx
+++ b/src/components/ui/ImageSlide.tsx
@@ -14,7 +14,7 @@ export default function ImageSlide({ children }: { children: ReactNode }) {
     // 네이티브 이미지 드래그(HTML5 dragstart)가 캐러셀의 포인터 드래그를 가로채
     // "넘어가다 마는" 현상을 막는다. preventDefault는 react-multi-carousel의
     // 마우스(mousedown/move) 기반 드래그에는 영향이 없다.
-    <div onDragStart={(e) => e.preventDefault()} className="select-none">
+    <div onDragStart={(e) => e.preventDefault()} className="w-full h-full select-none">
       <Carousel containerClass="w-full relative z-0 h-[100%]" responsive={responsive}>
         {children}
       </Carousel>


### PR DESCRIPTION
## 문제
상세 모달(PostDetail)에서 이미지가 모달을 뚫고 아래로 넘침.

## 원인
캐러셀 드래그 수정(#8) 때 추가한 `onDragStart` 래퍼 `div`에 높이가 없어, 안쪽 `<Carousel containerClass="...h-[100%]">`가 참조할 부모 높이가 사라짐 → `aspect-square` 이미지가 모달 높이를 넘어 세로로 자람.

## 수정
래퍼 div에 `w-full h-full` 추가 → 높이 체인 복원. 드래그 방지(`onDragStart` preventDefault)·`select-none`은 그대로 유지.

홈 카드(고정 width/height 이미지)는 영향 없음.

## 검증
- ✅ lint · typecheck · build green
- ✅ 브라우저에서 상세 모달 이미지가 모달 안에 맞는 것 확인 (작성자 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)