### PR TITLE
test(e2e): Playwright E2E (auth + feed flows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,26 @@ jobs:
           SANITY_STUDIO_SANITY_PROJECT_ID: dummy
           SANITY_STUDIO_SANITY_DATASET: production
           SANITY_SECRET_TOKEN: dummy
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        # Playwright builds + starts the app (placeholders below); session cookies
+        # are minted with AUTH_SECRET, so the value just has to match the server's.
+        run: npm run test:e2e
+        env:
+          AUTH_SECRET: e2e-ci-secret

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# playwright
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache
+
 # local working notes (not part of the deliverable)
 REFACTORING.md
 HANDOFF.md

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ npm run dev      # http://localhost:3000
 | `npm run typecheck` | `tsc --noEmit` |
 | `npm test` | Run the Vitest suite |
 | `npm run test:watch` | Vitest in watch mode |
+| `npm run test:e2e` | Run the Playwright E2E suite (builds + serves the app) |
+| `npm run seed` | Seed dummy posts into Sanity (`-- --count=N`, `--clean`) |
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1391,6 +1392,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6402,6 +6419,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "seed": "node --env-file=.env.local scripts/seed.mjs"
   },
   "dependencies": {
@@ -29,6 +30,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Shared secret used both to mint Auth.js session cookies (tests/e2e/fixtures.ts)
+// and by the app server below. Any value works as long as both sides match.
+process.env.AUTH_SECRET ||= 'e2e-test-secret-not-used-in-production-000000';
+
+// Dedicated test port so we never accidentally reuse a `next dev` server on 3000
+// (whose AUTH_SECRET would differ from the one used to mint test session cookies).
+const PORT = 3100;
+const baseURL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    // Production build so E2E exercises the same output that ships.
+    command: `npm run build && npm run start -- --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    env: {
+      AUTH_SECRET: process.env.AUTH_SECRET,
+      // The mocked flows never reach Google/Sanity, so placeholders are fine.
+      GOOGLE_OAUTH_ID: 'dummy',
+      GOOGLE_OAUTH_SECRET: 'dummy',
+      SANITY_STUDIO_SANITY_PROJECT_ID: 'dummy',
+      SANITY_STUDIO_SANITY_DATASET: 'production',
+      SANITY_SECRET_TOKEN: 'dummy',
+      ADMIN_ID: 'qustpwns93',
+      NEXT_PUBLIC_ADMIN_ID: 'qustpwns93',
+    },
+  },
+});

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { loginAs, mockApi, makePosts } from './fixtures';
+
+test.describe('unauthenticated', () => {
+  test('visiting / redirects to the sign-in page', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/api\/auth\/signin/);
+    await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+  });
+});
+
+test.describe('authenticated', () => {
+  test.beforeEach(async ({ context }) => {
+    await loginAs(context);
+  });
+
+  test('a logged-in user lands on the feed (no redirect)', async ({ page }) => {
+    await mockApi(page, { postsByPage: [makePosts(1)] });
+    await page.goto('/');
+    await expect(page).toHaveURL('/');
+    await expect(page.getByText('seed caption 0')).toBeVisible();
+  });
+});

--- a/tests/e2e/feed.spec.ts
+++ b/tests/e2e/feed.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { loginAs, mockApi, makePosts } from './fixtures';
+
+test.describe('feed (authenticated)', () => {
+  test.beforeEach(async ({ context }) => {
+    await loginAs(context);
+  });
+
+  test('renders the posts returned by the first page', async ({ page }) => {
+    await mockApi(page, { postsByPage: [makePosts(3)] });
+    await page.goto('/');
+
+    await expect(page.getByText('seed caption 0')).toBeVisible();
+    await expect(page.getByText('seed caption 2')).toBeVisible();
+    await expect(page.locator('article')).toHaveCount(3);
+  });
+
+  test('liking a post updates the count optimistically', async ({ page }) => {
+    await mockApi(page, { postsByPage: [makePosts(1)] });
+    await page.goto('/');
+
+    const article = page.locator('article').first();
+    await expect(article.getByText('0 like')).toBeVisible();
+
+    await article.getByRole('button', { name: 'like', exact: true }).click();
+
+    await expect(article.getByText('1 like')).toBeVisible();
+    // Button flips to the "unlike" affordance.
+    await expect(article.getByRole('button', { name: 'unlike', exact: true })).toBeVisible();
+  });
+
+  test('infinite scroll loads the next page', async ({ page }) => {
+    await mockApi(page, { postsByPage: [makePosts(5, 0), makePosts(3, 5)] });
+    await page.goto('/');
+
+    await expect(page.getByText('seed caption 0')).toBeVisible();
+    await expect(page.getByText('seed caption 5')).toHaveCount(0);
+
+    const page1 = page.waitForResponse(
+      (r) => r.url().includes('/api/posts') && new URL(r.url()).searchParams.get('page') === '1'
+    );
+    // The scroll container is <body> (globals.css: height:100vh; overflow:auto),
+    // not the window — scroll it to the bottom to trip the sentinel observer.
+    await page.evaluate(() => document.body.scrollTo(0, document.body.scrollHeight));
+    await page1;
+
+    await expect(page.getByText('seed caption 5')).toBeVisible();
+    await expect(page.getByText('seed caption 7')).toBeVisible();
+  });
+});

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,93 @@
+import { encode } from '@auth/core/jwt';
+import type { BrowserContext, Page } from '@playwright/test';
+import type { HomeUser } from '../../src/model/user';
+import type { SimplePost } from '../../src/model/post';
+
+// Auth.js v5 session cookie name on http (non-secure) origins like localhost.
+const SESSION_COOKIE = 'authjs.session-token';
+
+export const MOCK_USER: HomeUser = {
+  id: 'test-user-id',
+  name: 'Test User',
+  username: 'qustpwns93',
+  email: 'qustpwns93@gmail.com',
+  image: 'https://cdn.sanity.io/images/dummy/avatar.png',
+  following: [],
+  followers: [],
+  bookmarks: [],
+};
+
+// Build `count` posts with stable ids/text, optionally offset by `start` so
+// different pages don't collide.
+export function makePosts(count: number, start = 0): SimplePost[] {
+  return Array.from({ length: count }, (_, i) => {
+    const n = start + i;
+    return {
+      id: `post-${n}`,
+      username: MOCK_USER.username,
+      userImage: MOCK_USER.image!,
+      image: [`https://cdn.sanity.io/images/dummy/post-${n}.png`],
+      photos: [],
+      text: `seed caption ${n}`,
+      createdAt: new Date(Date.now() - n * 1000).toISOString(),
+      likes: [],
+      comments: 1,
+    };
+  });
+}
+
+// Mint a valid Auth.js session JWT and install it on the browser context so
+// `auth()` (server) and useMe/middleware treat the user as logged in.
+export async function loginAs(context: BrowserContext, user: HomeUser = MOCK_USER): Promise<void> {
+  const token = await encode({
+    salt: SESSION_COOKIE,
+    secret: process.env.AUTH_SECRET!,
+    token: { name: user.name, email: user.email, picture: user.image, id: user.id, sub: user.id },
+  });
+  await context.addCookies([
+    { name: SESSION_COOKIE, value: token, domain: 'localhost', path: '/', httpOnly: true, sameSite: 'Lax' },
+  ]);
+}
+
+// 1x1 transparent PNG so next/image requests resolve without hitting a real CDN.
+const STUB_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+type MockApiOptions = {
+  user?: HomeUser | null;
+  /** posts returned per page index, e.g. [page0Posts, page1Posts]. */
+  postsByPage?: SimplePost[][];
+};
+
+// Intercept the browser-side API calls the feed makes so tests stay
+// deterministic and never touch Sanity. Mutations resolve with 200.
+export async function mockApi(page: Page, { user = MOCK_USER, postsByPage = [] }: MockApiOptions = {}): Promise<void> {
+  await page.route('**/_next/image**', (route) =>
+    route.fulfill({ status: 200, contentType: 'image/png', body: STUB_PNG })
+  );
+
+  await page.route('**/api/me', (route) =>
+    user
+      ? route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(user) })
+      : route.fulfill({ status: 401, contentType: 'application/json', body: JSON.stringify({ error: 'Authentication Error' }) })
+  );
+
+  await page.route('**/api/posts**', (route) => {
+    const method = route.request().method();
+    if (method !== 'GET') {
+      // like/comment/delete mutations: succeed so optimistic UI commits.
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    }
+    const url = new URL(route.request().url());
+    const pageIndex = Number(url.searchParams.get('page') ?? '0');
+    const data = postsByPage[pageIndex] ?? [];
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(data) });
+  });
+
+  // Other mutations used by the feed (likes/comments/bookmarks).
+  await page.route(/\/api\/(likes|comments|bookmarks|follow)/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  );
+}


### PR DESCRIPTION
## 개요
REFACTORING.md §7 남은 핵심 항목인 **Playwright E2E**를 도입합니다. OAuth/Sanity를 건드리지 않고 결정론적으로 핵심 플로우를 검증합니다.

## 접근
- **세션 모킹**: `@auth/core/jwt`의 `encode`로 유효한 Auth.js v5 세션 쿠키를 발급해 로그인 상태를 시뮬레이션(Google OAuth 우회). `auth()`(서버)·미들웨어·`useMe`가 모두 인증으로 인식.
- **데이터 모킹**: 브라우저의 `/api/*` 호출을 `page.route`로 가로채 픽스처 반환(Sanity 무접촉). `next/image`는 1x1 PNG로 스텁.
- **전용 포트 3100**: `reuseExistingServer`가 3000의 dev 서버(AUTH_SECRET 다름)를 재사용하지 못하게 분리.

## 테스트 (5개, chromium)
- 미인증 `/` → sign-in 리다이렉트 + Google 버튼 노출
- 인증 시 피드 렌더(리다이렉트 없음)
- 첫 페이지 게시물 렌더(개수 검증)
- 좋아요 옵티미스틱 업데이트(`0 like`→`1 like`, 버튼 상태 토글)
- 무한 스크롤 → page=1 로드(body 스크롤 컨테이너 대응)

## 도구/CI
- `npm run test:e2e` 스크립트, `@playwright/test` devDependency
- CI에 `e2e` 잡 추가(chromium 설치 → build → 실행), README 스크립트 표 갱신
- `.gitignore`에 Playwright 산출물 추가

## 검증
- ✅ E2E 5/5 통과 (로컬 chromium)
- ✅ lint · typecheck · vitest(20) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)