### PR TITLE
style(ui): 다크 테마 전체 톤 정제

### DIFF
--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -4,10 +4,13 @@
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
     <html lang="en">
-      <body className="bg-black text-white">
+      <body className="bg-neutral-950 text-white">
         <div className="w-full flex flex-col items-center gap-4 py-24 text-center px-4">
           <h2 className="text-xl font-bold">문제가 발생했습니다.</h2>
-          <button className="bg-blue-color rounded-md py-2 px-8 font-bold" onClick={() => reset()}>
+          <button
+            className="bg-blue-color rounded-lg py-2 px-8 font-bold transition-colors hover:bg-sky-600 active:scale-[0.97]"
+            onClick={() => reset()}
+          >
             다시 시도
           </button>
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={openSans.className}>
-      <body className="w-full bg-black overflow-auto xl:h-full xl:flex ">
+      <body className="w-full bg-neutral-950 overflow-auto xl:h-full xl:flex ">
         <AuthContext>
-          <header className="sticky top-0 bg-black z-10 border-b border-white/30 xl:border-b-0 xl:border-r xl:w-[250px]">
+          <header className="sticky top-0 bg-neutral-950/90 backdrop-blur-sm z-10 border-b border-white/10 xl:border-b-0 xl:border-r xl:w-[250px]">
             <div className="max-w-screen-xl mx-auto">
               <Navbar />
             </div>

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -12,9 +12,9 @@ export default function CommentForm({ onPostComment, id }: Props) {
     setComment('');
   };
   return (
-    <form onSubmit={handleSubmit} className="flex items-center mb-1">
+    <form onSubmit={handleSubmit} className="flex items-center mb-1 border-t border-white/10 pt-1">
       <input
-        className="grow ml-2 border-none bg-black outline-none p-2 text-white"
+        className="grow ml-2 border-none bg-transparent outline-none p-2 text-white placeholder:text-white/40"
         type="text"
         placeholder="댓글 달기..."
         required

--- a/src/components/FollowingBar.tsx
+++ b/src/components/FollowingBar.tsx
@@ -11,7 +11,7 @@ export default function FollowingBar() {
   const users = user?.following;
 
   return (
-    <section className="w-full flex justify-center items-center p-4 mb-4 border border-white/70 rounded-md min-h-[90px] overflow-x-auto relative z-0">
+    <section className="w-full flex justify-center items-center p-4 mb-4 border border-white/10 rounded-xl bg-neutral-900/40 min-h-[90px] overflow-x-auto relative z-0">
       {isLoading ? (
         <Spinner />
       ) : (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -53,7 +53,7 @@ export default function Navbar() {
       <nav className="xl:w-full xl:px-2">
         <ul className="flex gap-3 items-center p-1 xsm:p-4 xsm:gap-4 xl:flex-col xl:items-start xl:gap-6 xl:p-0">
           {menu.map((item) => (
-            <li key={item.href} className="xl:w-full xl:px-4 py-2 xl:hover:bg-gray-800/80 xl:rounded-xl">
+            <li key={item.href} className="xl:w-full xl:px-4 py-2 xl:hover:bg-white/5 xl:rounded-xl xl:transition-colors">
               <Link href={item.href} aria-label={item.title} className="xl:w-full xl:flex xl:items-end xl:gap-2 ">
                 {pathName === item.href ? item.clickedIcon : item.icon}
                 <p className={`hidden xl:inline xl:text-white ${pathName === item.href && 'font-bold'}`}>{item.text}</p>
@@ -61,7 +61,7 @@ export default function Navbar() {
             </li>
           ))}
           {user && ( //
-            <li className="xl:w-full xl:px-4 py-2 xl:hover:bg-gray-800/80 xl:rounded-xl">
+            <li className="xl:w-full xl:px-4 py-2 xl:hover:bg-white/5 xl:rounded-xl xl:transition-colors">
               <Link
                 href={`/user/${user.username}`}
                 aria-label="User page"

--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -129,7 +129,7 @@ export default function PostDetail({ post }: Props) {
             </div>
           )}
           <PostUserAvatar image={userImage} username={username} />
-          <ul className="border-t border-b border-white/50 pt-3 mb-2 p-[4px] h-full overflow-auto   md:p-2 md:pr-6">
+          <ul className="border-t border-b border-white/10 pt-3 mb-2 p-[4px] h-full overflow-auto   md:p-2 md:pr-6">
             {comments &&
               comments.map(({ image, username: commentUsername, comment, key }, index) => (
                 <li key={`${comment}${index}`} className="flex items-center mb-1 relative pr-[20px] md:pr-0">

--- a/src/components/PostListCard.tsx
+++ b/src/components/PostListCard.tsx
@@ -41,7 +41,7 @@ export default function PostListCard({ post, priority = false }: Props) {
   };
 
   return (
-    <article className=" pb-2 border-b border-gray-200/50">
+    <article className=" pb-2 border-b border-white/10">
       <PostUserAvatar image={userImage} username={username} />
       <ImageSlide>
         {image &&

--- a/src/components/PostModal.tsx
+++ b/src/components/PostModal.tsx
@@ -37,7 +37,9 @@ export default function PostModal({ children, onClose }: Props) {
       <button className="fixed top-0 right-0 text-white p-2 md:p-8" aria-label="닫기" onClick={() => onClose()}>
         <CloseIcon />
       </button>
-      <div className="bg-black w-[90%] h-[85%] max-w-7xl md:w-[80%] md:h-3/5">{children}</div>
+      <div className="bg-neutral-950 rounded-2xl border border-white/10 overflow-hidden w-[90%] h-[85%] max-w-7xl md:w-[80%] md:h-3/5">
+        {children}
+      </div>
     </section>
   );
 }

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -7,7 +7,10 @@ type Props = {
 };
 export default function UserCard({ user: { name, username, image, following, followers } }: Props) {
   return (
-    <Link href={`/user/${username}`} className="flex items-center w-full bg-black p-2 hover:bg-menu-bg">
+    <Link
+      href={`/user/${username}`}
+      className="flex items-center w-full p-2 rounded-xl hover:bg-white/5 transition-colors"
+    >
       <Avatar image={image} />
       <div className="text-neutral-500 ml-2">
         <p className="text-white font-bold mb-[2px] leading-4">{username}</p>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -18,7 +18,7 @@ export default async function UserProfile({ user }: Props) {
     { title: '팔로우', data: following },
   ];
   return (
-    <section className="w-full text-white flex flex-col md:flex-row items-center justify-center py-12 border-b border-white/30">
+    <section className="w-full text-white flex flex-col md:flex-row items-center justify-center py-12 border-b border-white/10">
       <Avatar image={image} highlight size="xlarge" />
       <div className="md:ml-10 basis-1/3">
         <div className="flex flex-col items-center md:flex-row">

--- a/src/components/UserSearch.tsx
+++ b/src/components/UserSearch.tsx
@@ -31,7 +31,7 @@ export default function UserSearch() {
       <form className="w-full mb-4 relative px-4" onSubmit={onSubmit}>
         <SearchIcon type="user" />
         <input //
-          className="w-full text-xl p-3 px-10 text-white bg-black outline-none border border-white rounded-md "
+          className="w-full text-xl p-3 px-10 text-white bg-neutral-900 outline-none border border-white/15 rounded-xl transition-colors focus:border-white/40 placeholder:text-white/40 "
           type="text"
           autoFocus
           placeholder="검색"

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -7,8 +7,9 @@ type Props = {
 export default function Button({ text, onClick, red, disabled = false }: Props) {
   return (
     <button
-      className={`border-none rounded-md py-2 px-8 text-white font-bold leading-4
-      ${red ? 'bg-red-500 hover:bg-red-700' : 'bg-blue-color hover:bg-sky-700'} ${disabled && 'opacity-80'}
+      className={`border-none rounded-lg py-2 px-8 text-white font-bold leading-4
+      transition-all duration-150 active:scale-[0.97] disabled:active:scale-100
+      ${red ? 'bg-red-500 hover:bg-red-600' : 'bg-blue-color hover:bg-sky-600'} ${disabled && 'opacity-70 cursor-not-allowed'}
     `}
       onClick={() => onClick()}
       disabled={disabled}

--- a/src/components/ui/ColorButton.tsx
+++ b/src/components/ui/ColorButton.tsx
@@ -5,19 +5,16 @@ type Props = {
   type?: string;
 };
 export default function ColorButton({ text, onClick, size = 'small', type }: Props) {
+  const isBig = size === 'big';
   return (
     <div
-      className={`rounded-md bg-gradient-to-bl from-fuchsia-600 via-rose-500 to-amber-300 p-[0.15rem]
-    ${size === 'big' ? 'p[0.3rem]' : 'p-[0.15rem'}
-    ${type === 'nav' && 'xl:absolute xl:bottom-[50px] xl:left-[50%] xl:translate-x-[-50%] xl:w-[150px]'}
-    ${type === 'sign' && 'h-[38.5px]'}
-    `}
+      className={`rounded-lg bg-gradient-to-bl from-fuchsia-600 via-rose-500 to-amber-300 p-[2px]
+      ${type === 'nav' ? 'xl:absolute xl:bottom-[50px] xl:left-1/2 xl:-translate-x-1/2 xl:w-[150px]' : ''}
+      ${type === 'sign' ? 'h-[38.5px]' : ''}`}
     >
       <button
-        className={`bg-white rounded-sm text-base p-[0.3rem] hover:opacity-90 transition-opacity 
-    ${size === 'big' ? 'p-4 text-2xl' : 'p-[0.3rem text-base'} 
-    ${type === 'nav' && 'xl: w-full xl:rounded-[5px]'}
-    `}
+        className={`w-full bg-white rounded-[6px] font-semibold text-neutral-900 transition-all duration-150 hover:opacity-90 active:scale-[0.98]
+        ${isBig ? 'p-4 text-2xl' : 'px-4 py-[6px] text-base'}`}
         onClick={onClick}
       >
         {text}


### PR DESCRIPTION
## 개요
인스타 스타일 레이아웃은 유지하면서 다크 테마를 전반적으로 차분·일관되게 정제합니다. (방향: "전체 톤 정제")

## 변경
- **배경/깊이**: 순흑 `bg-black` → `bg-neutral-950`(#0a0a0a). 스티키 헤더에 `backdrop-blur` + `border-white/10`
- **구분선 정제**: 밝던 보더(`white/30·50·70`, `gray-200/50`) → 부드러운 `white/10`
- **서피스**: FollowingBar 카드(`bg-neutral-900/40`), 검색 입력(`bg-neutral-900` + focus 강조), 게시물 모달을 라운드+보더 패널로, UserCard/내비 hover → `white/5` + transition
- **버튼**: `rounded-lg` + `transition` + `active` 누름 효과. 댓글 입력은 `bg-transparent` + 상단 구분선
- **버그 정리**: `ColorButton`의 깨진 Tailwind 클래스(`p[0.3rem]`, 닫히지 않은 `p-[0.15rem` 등) 수정 → 의도대로 스타일 적용

## 검증
- ✅ lint · typecheck · build green
- ✅ E2E 5/5 통과 (셀렉터/동작 영향 없음)
- ⏳ **프리뷰에서 육안 확인 권장** (배경/보더/버튼 톤). 프리뷰는 새 auth env라 직접 로그인 테스트 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)